### PR TITLE
Add an option to build with CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ out/
 *.sdf
 *.opensdf
 build/
+build-w*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.7)
+project(Img2Spec)
+
+set(CMAKE_CXX_STANDARD 14)
+
+find_package(SDL2 REQUIRED)
+include_directories(${SDL2_INCLUDE_DIRS})
+include_directories("src/imgui" "src/parson" "src/stb")
+
+set(SOURCES
+        src/main.cpp
+        src/imgui/imgui.cpp
+        src/imgui/imgui_draw.cpp
+        src/imgui/imgui_impl_sdl.cpp
+        src/parson/parson.c
+        )
+
+add_definitions(-DIMGUI_INCLUDE_IMGUI_USER_INL)
+
+add_executable(img2spec WIN32 ${SOURCES})
+target_link_libraries(img2spec ${SDL2_LIBRARIES})
+
+if (WIN32)
+    target_link_libraries(img2spec opengl32 winmm imm32 version)
+endif ()

--- a/build_w32.sh
+++ b/build_w32.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Target triple (i686):
+TARGET=i686-w64-mingw32
+
+BUILD_DIR=./build-w32
+
+. ./build_windows.sh

--- a/build_w64.sh
+++ b/build_w64.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Target triple (x86_64):
+TARGET=x86_64-w64-mingw32
+
+BUILD_DIR=./build-w64
+
+. ./build_windows.sh

--- a/build_windows.sh
+++ b/build_windows.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# 
+# Cross compilation for Windows
+# This works on Arch Linux out of the box, just install mingw-w64-cmake from
+# AUR. (e.g. with yaourt -ySa mingw-w64-cmake)
+#
+# For other distros, having a look at Arch's package might be useful:
+# https://aur.archlinux.org/cgit/aur.git/tree/?h=mingw-w64-cmake
+
+set -x -e
+
+rm -rf ${BUILD_DIR}
+mkdir ${BUILD_DIR}
+cd ${BUILD_DIR}
+
+${TARGET}-cmake -DCMAKE_EXE_LINKER_FLAGS="-static" -DCMAKE_BUILD_TYPE="Release" ..
+make

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,7 +25,7 @@ Still, if you find it useful, great!
 */
 
 #define _CRT_SECURE_NO_WARNINGS
-#include <Windows.h>
+#include <windows.h>
 #include "imgui.h"
 #include "imgui_impl_sdl.h"
 
@@ -35,7 +35,7 @@ Still, if you find it useful, great!
 #include <SDL_syswm.h>
 #include <SDL_opengl.h>
 
-#include "parson\parson.h"
+#include "parson/parson.h"
 
 #define STB_IMAGE_IMPLEMENTATION
 #include "stb_image.h"
@@ -173,7 +173,6 @@ void update_texture(GLuint aTexture, unsigned int *aBitmap)
 		GL_UNSIGNED_BYTE,		// type
 		(GLvoid*)aBitmap);		// data
 }
-
 
 int getFileDate(char *aFilename)
 {


### PR DESCRIPTION
I am looking into making this tool cross-platform. This is the first step to make it possible.
I've tested this CMake configuration on Arch Linux, cross-compiling with [mingw-w64](https://aur.archlinux.org/packages/mingw-w64-gcc) for Windows. (that's what the included build_w32/64.sh scripts are for)

CMake can generate Visual Studio project files as well (for all available generators see: https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html ). In order to do so, run a command like the following one from a project's subdirectory (e.g. from a subdirectory called "build")
```
cmake -G"Visual Studio 12 2013" -T v130_xp ..
```
Then open the generated project file.
The `-T` option specifies the ""Platform Toolset."